### PR TITLE
Allow relay devices that use the light domain for the switches

### DIFF
--- a/custom_components/lunos/__init__.py
+++ b/custom_components/lunos/__init__.py
@@ -5,9 +5,10 @@ https://github.com/rsnodgrass/hass-lunos
 
 import logging
 import os
-
 import yaml
 
+from homeassistant.helpers.discovery import load_platform
+from .const import LUNOS_DOMAIN
 
 LOG = logging.getLogger(__name__)
 
@@ -23,5 +24,19 @@ except Exception as e:
 
 
 async def async_setup(hass, config):
-    LOG.info(f'LUNOS controller codings supported: {LUNOS_CODING_CONFIG.keys()}')
+    LOG.info(f"LUNOS controller codings supported: {LUNOS_CODING_CONFIG.keys()}")
+
+    conf = config.get(LUNOS_DOMAIN)
+    if conf is None:
+        LOG.info("No LUNOS configuration found")
+        return True
+
+    load_platform(
+        hass,
+        "fan",
+        LUNOS_DOMAIN,
+        None,
+        conf,
+    )
+
     return True


### PR DESCRIPTION
My relay device - Huacaoe 2-channel relay board - recognizes the switch entities as `light.<entity>` instead of `switch.<entity>`. It was able to read the state of the relays, but it was not initially able to update them. I took a quick stab at forking and updating the codebase to support either switch or light. I got it working for me, but would love to push this back into the official HACS project so I could install it from there instead of the way I have it as a custom integration.

I am not too familiar with your codebase. I suspect only my changes to the fan.py would be necessary, but I had to make the changes to `__init__.py` to get it to work. Here's the config I ended up using...

``` yaml
fan:
  - platform: lunos
    name: Lunos e2 - Great Room
    relay_w1: light.lunos_e2_great_room_light_1
    relay_w2: light.lunos_e2_great_room_light_2
```